### PR TITLE
Declare license using SPDX

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "name": "Gleb Khudyakov",
     "url": "https://github.com/hydiak/a-sync-waterfall"
   },
+  "license": "MIT",
   "homepage": "https://github.com/hydiak/a-sync-waterfall",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The package does not contain the license identifier which makes it tricky to use the package as it can be treated as unlicensed code as the package doesn't delcare the license upfront.

@hydiak Please could add the license metadata to the package and make a patch release of the package for this as a-sync-waterfall is used by many packages making it tricky to get past lawyers and license checking tools.